### PR TITLE
Bump to Scalatra 2.6 & Scala 2.12.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ lazy val root = (project in file(".")).enablePlugins(SbtTwirl)
 organization := Organization
 name := ProjectName
 version := ProjectVersion
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 libraryDependencies ++= Seq(
-  "io.github.gitbucket"   %% "gitbucket"            % "4.17.0"  % "provided",
+  "io.github.gitbucket"   %% "gitbucket"            % "4.19.0"  % "provided",
   "io.github.gitbucket"   % "solidbase"             % "1.0.2"   % "provided",
   "com.typesafe.play"     %% "twirl-compiler"       % "1.3.0"   % "provided",
   "org.apache.commons"    % "commons-email"         % "1.4"     % "provided",

--- a/src/main/scala/fr/brouillard/gitbucket/announce/controller/AnnounceController.scala
+++ b/src/main/scala/fr/brouillard/gitbucket/announce/controller/AnnounceController.scala
@@ -8,7 +8,7 @@ import gitbucket.core.controller.ControllerBase
 import gitbucket.core.service.{AccountService, SystemSettingsService}
 import gitbucket.core.util.{AdminAuthenticator, Mailer}
 import io.github.gitbucket.markedj.{Marked, Options}
-import io.github.gitbucket.scalatra.forms._
+import org.scalatra.forms._
 import org.apache.commons.mail.EmailException
 import org.slf4j.LoggerFactory
 import gitbucket.core.util.Implicits._


### PR DESCRIPTION
fix GitBucket 4.19.0

> Caused by: java.lang.ClassNotFoundException: io.github.gitbucket.scalatra.forms.package$ValueType
>        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
>        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
>        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)

see https://github.com/gitbucket/gitbucket-pages-plugin/pull/23